### PR TITLE
RDKB-36934 : Add rbus messaging api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else ()
 endif ()
 
 
-set(CMAKE_C_FLAGS_DEBUG "-Wall -Werror -Wextra -Wno-type-limits -g -fno-inline")
+set(CMAKE_C_FLAGS_DEBUG "-Wall -Wextra -Wextra -Wno-type-limits -g -fno-inline")
 set(CMAKE_C_FLAGS_RELEASE "-Werror -Wall -Wextra")
 
 if (ENABLE_CODE_COVERAGE)

--- a/include/rbus.h
+++ b/include/rbus.h
@@ -87,10 +87,10 @@ extern "C" {
 /** @addtogroup Common
  *  @{
  */
-struct _rbusHandle_t;
+struct _rbusHandle;
 
 ///  @brief     An RBus handle which identifies an opened component
-typedef struct _rbusHandle_t* rbusHandle_t;
+typedef struct _rbusHandle* rbusHandle_t;
 
 ///  @brief     The maximum length a name can be for any element.
 #define RBUS_MAX_NAME_LENGTH 256
@@ -138,6 +138,9 @@ typedef enum _rbusError
     RBUS_ERROR_TIMEOUT,                         /**< The operation timedout   */
     RBUS_ERROR_ASYNC_RESPONSE                   /**< The method request will be handle asynchronously by provider */
 } rbusError_t;
+
+
+char const * rbusError_ToString(rbusError_t e);
 
 /** @struct     rbusSetOptions_t
  *  @brief      Additional options a client can pass to a set function.
@@ -190,10 +193,10 @@ typedef struct _rbusSetHandlerOptions
     char const* requestingComponent;    /**< Component that invoking the SET method. */
 } rbusSetHandlerOptions_t;
 
-struct _rbusMethodAsyncHandle_t;
+struct _rbusMethodAsyncHandle;
 
 ///  @brief     An RBus handle used for async method responses
-typedef struct _rbusMethodAsyncHandle_t* rbusMethodAsyncHandle_t;
+typedef struct _rbusMethodAsyncHandle* rbusMethodAsyncHandle_t;
 
 /** @addtogroup Events
  *  @{
@@ -232,7 +235,7 @@ typedef struct
     rbusFilter_t  filter;       /**< Optional filter that was applied by provider*/
 } rbusEvent_t;
 
- typedef struct _rbusEventSubscription rbusEventSubscription_t;
+typedef struct _rbusEventSubscription rbusEventSubscription_t;
 
 /** @fn typedef void (* rbusSubscribeAsyncRespHandler_t)(
  *          rbusHandle_t              handle,
@@ -322,7 +325,7 @@ typedef void (*rbusMethodAsyncRespHandler_t)(
   * @{ 
   */
 
- /// @brief rbusElementType_t indicates the type of data elements which can be registered with RBus
+/// @brief rbusElementType_t indicates the type of data elements which can be registered with RBus
 typedef enum 
 {
     RBUS_ELEMENT_TYPE_PROPERTY  = 1,    /**< Property Element. 
@@ -359,7 +362,6 @@ typedef rbusError_t (*rbusGetHandler_t)(
     rbusProperty_t property,
     rbusGetHandlerOptions_t* options
 );
-
 
 /** @fn typedef rbusError_t (*rbusSetHandler_t)(
  *          rbusHandle_t handle, 
@@ -495,7 +497,6 @@ typedef rbusError_t (* rbusEventSubHandler_t)(
     bool* autoPublish
 );
 
-
 /** @struct rbusCallbackTable_t
  *  @brief The list of callback handlers supported by a data element.
  *
@@ -544,7 +545,6 @@ typedef struct
                                              callback can be NULL, if no usage*/
 }rbusDataElement_t;
 
-
 /**
  * @enum        rbusStatus_t
  * @brief       The type of events which can be subscribed to or published
@@ -564,12 +564,12 @@ typedef enum
   RBUS_LOG_WARN  = 2,
   RBUS_LOG_ERROR = 3,
   RBUS_LOG_FATAL = 4
-} rbusLogLevel;
+} rbusLogLevel_t;
 
-
+typedef rbusLogLevel_t rbusLogLevel;
 
 /** @fn typedef void (*rbusLogHandler)(
- *          rbusLogLevel level,
+ *          rbusLogLevel_t level,
  *          const char* file,
  *          int line,
  *          int threadId,
@@ -586,7 +586,7 @@ typedef enum
  *  @return                     None.
  */
 typedef void (*rbusLogHandler)(
-    rbusLogLevel level,
+    rbusLogLevel_t level,
     const char* file,
     int line,
     int threadId,
@@ -611,7 +611,7 @@ rbusStatus_t rbus_checkStatus(
 
 /** @fn rbusError_t rbus_open(
  *          rbusHandle_t* handle, 
- *          char *componentName)
+ *          char const* componentName)
  *  @brief  Open a bus connection for a software component.
  *  If multiple components share a software process, the first component that
  *  calls this API will establishes a new socket connection to the bus broker.
@@ -633,7 +633,7 @@ rbusStatus_t rbus_checkStatus(
  */
 rbusError_t rbus_open(
     rbusHandle_t* handle, 
-    char *componentName);
+    char const* componentName);
 
 /** @fn rbusError_t rbus_close(
  *          rbusHandle_t handle)
@@ -1420,7 +1420,7 @@ rbusError_t rbus_registerLogHandler(
     rbusLogHandler logHandler);
 
 /** @fn rbusError_t rbus_setLogLevel(
- *          rbusLogLevel level)
+ *          rbusLogLevel_t level)
  *
  *  @brief  Component use this API to set the log level to be printed
  *
@@ -1430,13 +1430,16 @@ rbusError_t rbus_registerLogHandler(
  *  @return RBus error code as defined by rbusError_t.
  */
 
-rbusError_t rbus_setLogLevel(rbusLogLevel level);
+rbusError_t rbus_setLogLevel(rbusLogLevel_t level);
 
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <rbus_message.h>
+
 #endif
 
 /** @} */

--- a/include/rbus_message.h
+++ b/include/rbus_message.h
@@ -1,0 +1,143 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2019 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**
+ * @file        rubs_message.h
+ * @brief       rbusMessage
+ * @defgroup    rbusMessage
+ * @brief       rbusMessage is a publish/subscribe api which allows rbus
+                apps to send and receive binary data.
+ * @{
+ */
+
+#ifndef RBUS_MESSAGE_H
+#define RBUS_MESSAGE_H
+
+#include <rbus.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct      rbusMessage_t
+ * @brief       The data associated with a sent message
+ */
+typedef struct
+{
+    char const*     topic;      /**< The topic the message is sent to */
+    uint8_t const*  data;       /**< The binary data being sent */
+    int             length;     /**< The binary data length */
+} rbusMessage_t;
+
+/**
+ * @enum        rbusMessageOption_t
+ * @brief       Option which controls how messages are sendt
+ */
+typedef enum
+{
+  RBUS_MESSAGE_NONE = 0, /**< The message is sent non-blocking with no
+                                         confirmation of delivery */
+  RBUS_MESSAGE_CONFIRM_RECEIPT = 1     /**< The message is sent, blocking until a response
+                                         returns indicating whether the message
+                                         was received by a listener or not */
+} rbusMessageSendOptions_t;
+
+/** @fn typedef void (*rbusMessageHandler_t)(
+ *          rbusHandle_t handle, 
+ *          rbusMessage_t message, 
+ *          void* userData)
+ *  @brief A component will receive this API callback when a message is received.
+ *  This callback is registered with rbusMessage_AddListener.\n
+ *  Used by: Any component that listens for messages.
+ *  @param handle Bus Handle
+ *  @param message The message being sent to the listener
+ *  @param userData The user data set when adding the listener
+ *  @return void
+ */
+typedef void (*rbusMessageHandler_t)(
+    rbusHandle_t handle, 
+    rbusMessage_t* message, 
+    void* userData);
+
+/** @fn rbusError_t rbusMessage_AddListener(
+ *          rbusHandle_t handle,
+ *          char const* expression,
+ *          rbusMessageHandler_t callback,
+ *          void * userData)
+ *  @brief  Add a message listener.
+ *  @param  handle Bus Handle
+ *  @param  expression A topic or a topic expression
+ *  @param  handler The message callback handler
+ *  @param  userData User data to be passed back to the callback handler
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+rbusError_t rbusMessage_AddListener(
+    rbusHandle_t handle,
+    char const* expression,
+    rbusMessageHandler_t handler,
+    void* userData);
+
+/** @fn rbusError_t rbusMessage_RemoveListener(
+ *          rbusHandle_t handle,
+ *          char const* expression)
+ *  @brief  Remove a message listener.
+ *  @param  handle Bus Handle
+ *  @param  expression A topic or a topic expression
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+rbusError_t rbusMessage_RemoveListener(
+    rbusHandle_t handle,
+    char const* expression);
+
+/** @fn rbusError_t rbusMessage_RemoveAllListeners(
+ *          rbusHandle_t handle,
+ *          char const* expression)
+ *  @brief  Remove all message listeners.
+ *  @param  handle Bus Handle
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+rbusError_t rbusMessage_RemoveAllListeners(
+    rbusHandle_t handle);
+
+/** @fn rbusError_t rbusMessage_Send(
+ *          rbusHandle_t handle,
+ *          rbusMessage_t* message,
+ *          rbusMessageSendOptions_t opts)
+ *  @brief  Send a message.
+ *  @param  handle Bus Handle
+ *  @param  message The message to send
+ *  @param  opts Options to control how the message is sent
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR, RBUS_ERROR_DESTINATION_NOT_FOUND
+ */
+rbusError_t rbusMessage_Send(
+    rbusHandle_t handle,
+    rbusMessage_t* message,
+    rbusMessageSendOptions_t opts);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+/** @} */

--- a/sampleapps/CMakeLists.txt
+++ b/sampleapps/CMakeLists.txt
@@ -76,6 +76,14 @@ add_executable(rbusMethodConsumer consumer/rbusMethodConsumer.c)
 add_dependencies(rbusMethodConsumer rbus)
 target_link_libraries(rbusMethodConsumer rbus)
 
+add_executable(rbusMessageListener message/rbusMessageListener.c)
+add_dependencies(rbusMessageListener rbus)
+target_link_libraries(rbusMessageListener rbus)
+
+add_executable(rbusMessageSender message/rbusMessageSender.c)
+add_dependencies(rbusMessageSender rbus)
+target_link_libraries(rbusMessageSender rbus)
+
 add_executable(rbusTR104MtaAgentApp provider/mta_proxy_tr104.c
 provider/mta_hal_tr104.c provider/mta_hal_tr104.h)
 add_dependencies(rbusTR104MtaAgentApp rbus)
@@ -95,6 +103,8 @@ install (TARGETS
     rbusGeneralEventConsumer
     rbusValueChangeProvider
     rbusValueChangeConsumer
+    rbusMessageListener
+    rbusMessageSender
     RUNTIME DESTINATION bin)
 
 endif (BUILD_RBUS_INTERFACE_SAMPLE_APPS)

--- a/sampleapps/message/rbusMessageListener.c
+++ b/sampleapps/message/rbusMessageListener.c
@@ -1,0 +1,62 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2019 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <rbus.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+int running = 1;
+
+static void rbusMessageHandler(rbusHandle_t handle, rbusMessage_t* msg, void * userData)
+{
+    (void)handle;
+    (void)userData;
+    printf("rbusMessageHandler topic=%s data=%.*s\n", msg->topic, msg->length, (char const *)msg->data);
+
+    if(strstr((const char*)msg->data, "Goodbye") != 0)
+    {
+        printf("quiting app\n");     
+        running = 0;
+    }
+}
+
+int main()
+{
+    rbusError_t err;
+    rbusHandle_t rbus;
+
+    err = rbus_open(&rbus, "rbus_recv");
+    if (err)
+    {
+        fprintf(stderr, "rbus_open:%s\n", rbusError_ToString(err));
+        return 1;
+    }
+
+    rbusMessage_AddListener(rbus, "A.B.C", &rbusMessageHandler, NULL);
+
+    while (running)
+    {
+        sleep(1);
+    }
+
+    rbus_close(rbus);
+
+    return 0;
+}

--- a/sampleapps/message/rbusMessageSender.c
+++ b/sampleapps/message/rbusMessageSender.c
@@ -1,0 +1,66 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2019 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <rbus.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+int main()
+{
+    rbusError_t err;
+    rbusHandle_t rbus;
+    char topic[] = "A.B.C";
+    char buff[256];
+    rbusMessage_t msg;
+
+    err = rbus_open(&rbus, "rbus_send");
+    if (err) {
+        fprintf(stderr, "rbus_open:%s\n", rbusError_ToString(err));
+        return 0;
+    }
+
+    msg.topic = topic;
+    msg.data = (uint8_t*)buff;
+    
+    msg.length = snprintf(buff, sizeof(buff), "%ld: Hello!", time(NULL));
+    
+    err = rbusMessage_Send(rbus, &msg, RBUS_MESSAGE_CONFIRM_RECEIPT);
+    if (err)
+    {
+        fprintf(stderr, "rbusMessage_Send:%s\n", rbusError_ToString(err));
+        goto cleanup;
+    }
+
+    sleep(1);
+ 
+    msg.length = snprintf(buff, sizeof(buff), "%ld: Goodbye!", time(NULL));
+
+    err = rbusMessage_Send(rbus, &msg, RBUS_MESSAGE_CONFIRM_RECEIPT);
+    if (err)
+    {
+        fprintf(stderr, "rbusMessage_Send:%s\n", rbusError_ToString(err));
+        goto cleanup;
+    }
+
+    cleanup:
+    rbus_close(rbus);
+
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
     rbus
     SHARED
     rbus.c
+    rbus_message.c
     rbus_value.c
     rbus_property.c
     rbus_object.c

--- a/src/rbus_handle.h
+++ b/src/rbus_handle.h
@@ -1,0 +1,26 @@
+#ifndef RBUS_HANDLE_H
+#define RBUS_HANDLE_H
+
+#include "rbus_element.h"
+#include "rbus_subscriptions.h"
+#include <rtConnection.h>
+#include <rtVector.h>
+
+struct _rbusHandle
+{
+  int                   inUse;
+  char*                 componentName;
+  elementNode*          elementRoot;
+
+  /* consumer side subscriptions FIXME - 
+    this needs to be an associative map instead of list/vector*/
+  rtVector              eventSubs; 
+
+  /* provider side subscriptions */
+  rbusSubscriptions_t   subscriptions; 
+
+  rtVector              messageCallbacks;
+  rtConnection          connection;
+};
+
+#endif

--- a/src/rbus_log.h
+++ b/src/rbus_log.h
@@ -43,12 +43,12 @@
 
 #else
 
-#define RBUSLOG_TRACE(format...)        rtLog_Debug(format)
-#define RBUSLOG_DEBUG(format...)        rtLog_Debug(format)
-#define RBUSLOG_INFO(format...)         rtLog_Info(format)
-#define RBUSLOG_WARN(format...)         rtLog_Warn(format)
-#define RBUSLOG_ERROR(format...)        rtLog_Error(format)
-#define RBUSLOG_FATAL(format...)        rtLog_Fatal(format)
+#define RBUSLOG_TRACE rtLog_Debug
+#define RBUSLOG_DEBUG rtLog_Debug
+#define RBUSLOG_INFO rtLog_Info
+#define RBUSLOG_WARN rtLog_Warn
+#define RBUSLOG_ERROR rtLog_Error
+#define RBUSLOG_FATAL rtLog_Fatal
 
 #endif /* ENABLE_RDKLOGGER */
 #endif

--- a/src/rbus_message.c
+++ b/src/rbus_message.c
@@ -1,0 +1,185 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2021 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+#include "rbus.h"
+#include "rbus_handle.h"
+#include <string.h>
+
+typedef struct
+{
+    rbusHandle_t          handle;
+    char*                 expression;
+    rbusMessageHandler_t  handler;
+    void*                 userData;
+    rtConnection          connection;
+} rbusMessageHandlerContext_t;
+
+rbusError_t rtError_to_rBusError(rtError e)
+{
+    rbusError_t err;
+    switch (e)
+    {
+    case RT_OBJECT_NO_LONGER_AVAILABLE:
+        err = RBUS_ERROR_DESTINATION_NOT_FOUND;
+        break;
+    default:
+        err = RBUS_ERROR_BUS_ERROR;
+        break;
+    }
+    return err;
+}
+
+static void rtMessage_CallbackHandler(rtMessageHeader const* hdr, uint8_t const* buff, uint32_t n, void* userData)
+{
+    rbusMessageHandlerContext_t* ctx = (rbusMessageHandlerContext_t*)userData;
+
+    // if this is request, the sender wants confirmation of receipt
+    // do that before dispatching application callback
+    if (rtMessageHeader_IsRequest(hdr))
+    {
+        uint8_t res = 0;
+        uint32_t resLength = (uint32_t) sizeof(res);
+
+        rtError e = rtConnection_SendBinaryResponse(ctx->connection, hdr, &res, resLength, 2000);
+        if (e != RT_OK)
+        {
+            RBUSLOG_WARN("error sending response for confirmed receipt. %s", rtStrError(e));
+        }
+    }
+
+    if (ctx->handler)
+    {
+        rbusMessage_t message;
+        message.topic = hdr->topic;
+        message.data = buff;
+        message.length = n;
+
+        ctx->handler(ctx->handle, &message, ctx->userData);
+    }
+}
+
+static void cleanupContext(void * p)
+{
+    rbusMessageHandlerContext_t* ctx = (rbusMessageHandlerContext_t*)p;
+    if(ctx->expression)
+        free(ctx->expression);
+    free(ctx);
+}
+
+static int compareContextExpression(const void *left, const void *right)
+{
+    return strcmp(((const rbusMessageHandlerContext_t*)left)->expression, (const char*)right);
+}
+
+rbusError_t rbusMessage_AddListener(
+    rbusHandle_t handle,
+    char const* expression,
+    rbusMessageHandler_t handler,
+    void* userData)
+{
+    rtConnection con = ((struct _rbusHandle*)handle)->connection;
+
+    rbusMessageHandlerContext_t* ctx = malloc(sizeof(rbusMessageHandlerContext_t));
+    ctx->handle = handle;
+    ctx->expression = strdup(expression);
+    ctx->handler = handler;
+    ctx->userData = userData;
+    ctx->connection = con;
+    rtVector_PushBack(handle->messageCallbacks, ctx);
+
+    rtError e = rtConnection_AddListener(con, expression, &rtMessage_CallbackHandler, ctx);
+    if (e != RT_OK)
+    {
+        RBUSLOG_WARN("rtConnection_AddListener:%s", rtStrError(e));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+rbusError_t rbusMessage_RemoveListener(
+    rbusHandle_t handle,
+    char const* expression)
+{
+    rtConnection con = ((struct _rbusHandle*)handle)->connection;
+
+    rtVector_RemoveItemByCompare(handle->messageCallbacks, expression, compareContextExpression, cleanupContext);
+
+    rtError e = rtConnection_RemoveListener(con, expression);
+    if (e != RT_OK)
+    {
+        RBUSLOG_WARN("rtConnection_RemoveListener:%s", rtStrError(e));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+rbusError_t rbusMessage_RemoveAllListeners(
+    rbusHandle_t handle)
+{
+    rtConnection con = ((struct _rbusHandle*)handle)->connection;
+    int i, n;
+
+    for (i = 0, n = rtVector_Size(handle->messageCallbacks); i < n; ++i)
+    {
+        rbusMessageHandlerContext_t* ctx = rtVector_At(handle->messageCallbacks, i);
+        rtError e = rtConnection_RemoveListener(con, ctx->expression);
+        if (e != RT_OK)
+        {
+            RBUSLOG_WARN("rbusMessage_RemoveAllListener %s :%s", ctx->expression, rtStrError(e));
+        }    
+        free(ctx->expression);
+        free(ctx);
+    }
+    return RBUS_ERROR_SUCCESS;
+}
+
+rbusError_t rbusMessage_Send(
+    rbusHandle_t handle,
+    rbusMessage_t* message,
+    rbusMessageSendOptions_t opts)
+{
+    rtConnection con = ((struct _rbusHandle*)handle)->connection;
+
+    if (opts & RBUS_MESSAGE_CONFIRM_RECEIPT)
+    {
+        uint8_t * res = NULL;
+        uint32_t  resLength = 0;
+
+        rtError e = rtConnection_SendBinaryRequest(con, message->data, message->length, message->topic, &res, &resLength, 2000);
+        if (e != RT_OK)
+        {
+            RBUSLOG_WARN("rtConnection_SendRequest:%s", rtStrError(e));
+            return rtError_to_rBusError(e);
+        }
+        if(res)
+            free(res);
+    }
+    else
+    {
+        rtError e = rtConnection_SendBinary(con, message->data, message->length, message->topic);
+        if (e != RT_OK)
+        {
+            RBUSLOG_WARN("rtConnection_SendBinary:%s", rtStrError(e));
+            return rtError_to_rBusError(e);
+        }
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}


### PR DESCRIPTION
Reason for change: Adding basic pub/sub api to rbus which allows rbus apps to
send binary data over the bus using the underlying rtMessage connection
without having to register data elements.
Test Procedure: run rbusMessageListener and rbusMessageSender
Risks: Low
Signed-off-by: mrollins <mark_rollins@cable.comcast.com>
Change-Id: I452344931b511c137e452f0442db6ea08656c5ae